### PR TITLE
Add aws fhd script flags, some defensive code for paths, and versions changes

### DIFF
--- a/FHD_IDL_wrappers/mjw_fhd_versions.pro
+++ b/FHD_IDL_wrappers/mjw_fhd_versions.pro
@@ -65,6 +65,25 @@ pro mjw_fhd_versions
     restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
     end
 
+    'kernel_window_rfi_sim_1x_run': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='/uvfits/extra_vis/1061312640_nsamplemax_RFI_plaw.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
+    end
+
     'kernel_window_rfi_sim_run': begin
     kernel_window=1
     calibrate_visibilities=0
@@ -81,6 +100,63 @@ pro mjw_fhd_versions
     interpolate_kernel=1
     restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
     extra_vis_filepath='/uvfits/extra_vis/1061312640_nsamplemax_RFI_plaw_10x.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
+    end
+
+    'kernel_window_rfi_sim_100x_run': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='/uvfits/extra_vis/1061312640_nsamplemax_RFI_plaw_100x.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
+    end
+
+    'kernel_window_rfi_sim_1000x_run': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='/uvfits/extra_vis/1061312640_nsamplemax_RFI_plaw_1000x.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
+    end
+
+    'kernel_window_rfi_sim_1000s_run': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='/uvfits/extra_vis/1061312640_nsamplemax_RFI_plaw_1000s.uvfits'
     in_situ_sim_input='/uvfits/input_vis/vis_data'
     end
 

--- a/FHD_IDL_wrappers/mjw_fhd_versions.pro
+++ b/FHD_IDL_wrappers/mjw_fhd_versions.pro
@@ -239,6 +239,46 @@ pro mjw_fhd_versions
     remove_sim_flags=1
     end
 
+    'kernel_window_rfi_sim_single_source_run_no_bubbles_MBZ7': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='/uvfits/extra_vis/1061315448_NB_RFI_MBZ7_nsamplemax.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
+    remove_sim_flags=1
+    end
+
+    'kernel_window_rfi_sim_single_source_run_no_bubbles_MBZ7_mJy': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='/uvfits/extra_vis/1061315448_NB_RFI_MBZ7_mJy_nsamplemax.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
+    remove_sim_flags=1
+    end
+
     'kernel_window_rfi_sim_single_source_run_no_bubbles_MB_single_model': begin
     kernel_window=1
     calibrate_visibilities=0
@@ -257,6 +297,7 @@ pro mjw_fhd_versions
     extra_vis_filepath='/uvfits/extra_vis/1061315448_NB_midband_RFI_nsamplemax.uvfits'
     in_situ_sim_input='/uvfits/input_vis/vis_data'
     remove_sim_flags=1
+    model_catalog_file_path = filepath('test_RFI_source_1061315448_zenith.sav',root=rootdir('FHD'),subdir='catalog_data')
     end
 
     'kernel_window_rfi_sim_single_source_run_no_bubbles_DTV_single_model': begin
@@ -277,6 +318,70 @@ pro mjw_fhd_versions
     extra_vis_filepath='/uvfits/extra_vis/1061315448_DTV_RFI_nsamplemax.uvfits'
     in_situ_sim_input='/uvfits/input_vis/vis_data'
     remove_sim_flags=1
+    model_catalog_file_path = filepath('test_RFI_source_1061315448_zenith.sav',root=rootdir('FHD'),subdir='catalog_data')
+    end
+
+    'kernel_window_rfi_sim_single_source_run_no_bubbles_DTV6_single_model': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='/uvfits/extra_vis/1061315448_DTV6_RFI_nsamplemax.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
+    remove_sim_flags=1
+    model_catalog_file_path = filepath('test_RFI_source_1061315448_zenith.sav',root=rootdir('FHD'),subdir='catalog_data')
+    end
+
+    'kernel_window_rfi_sim_single_source_run_no_bubbles_Double_DTV_single_model': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='/uvfits/extra_vis/1061315448_Double_DTV_RFI_nsamplemax.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
+    remove_sim_flags=1
+    model_catalog_file_path = filepath('test_RFI_source_1061315448_zenith.sav',root=rootdir('FHD'),subdir='catalog_data')
+    end
+
+    'kernel_window_rfi_sim_single_source_run_no_bubbles_Double_DTV_single_model_mJy': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='/uvfits/extra_vis/1061315448_Double_DTV_mJy_RFI_nsamplemax.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
+    remove_sim_flags=1
+    model_catalog_file_path = filepath('test_RFI_source_1061315448_zenith.sav',root=rootdir('FHD'),subdir='catalog_data')
     end
 
     'kernel_window_rfi_sim_1000s_run': begin

--- a/FHD_IDL_wrappers/mjw_fhd_versions.pro
+++ b/FHD_IDL_wrappers/mjw_fhd_versions.pro
@@ -65,6 +65,23 @@ pro mjw_fhd_versions
     restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
     end
 
+    'kernel_window_control_run_zenith': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    end
+
     'kernel_window_rfi_sim_1x_run': begin
     kernel_window=1
     calibrate_visibilities=0
@@ -141,6 +158,127 @@ pro mjw_fhd_versions
     in_situ_sim_input='/uvfits/input_vis/vis_data'
     end
 
+    'kernel_window_rfi_sim_single_source_run': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='/uvfits/extra_vis/1061315448_NB_RFI_nsamplemax.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
+    eor_vis_filepath='/uvfits/input_eor/vis_data'
+    remove_sim_flags=1
+    end
+
+    'kernel_window_rfi_sim_single_source_run_no_bubbles': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='/uvfits/extra_vis/1061315448_NB_RFI_nsamplemax.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
+    remove_sim_flags=1
+    end
+
+    'kernel_window_rfi_sim_single_source_run_no_bubbles_MB_100x': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='/uvfits/extra_vis/1061315448_NB_midband_100x_RFI_nsamplemax.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
+    remove_sim_flags=1
+    end
+
+    'kernel_window_rfi_sim_single_source_run_no_bubbles_MB': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='/uvfits/extra_vis/1061315448_NB_midband_RFI_nsamplemax.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
+    remove_sim_flags=1
+    end
+
+    'kernel_window_rfi_sim_single_source_run_no_bubbles_MB_single_model': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='/uvfits/extra_vis/1061315448_NB_midband_RFI_nsamplemax.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
+    remove_sim_flags=1
+    end
+
+    'kernel_window_rfi_sim_single_source_run_no_bubbles_DTV_single_model': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='/uvfits/extra_vis/1061315448_DTV_RFI_nsamplemax.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
+    remove_sim_flags=1
+    end
+
     'kernel_window_rfi_sim_1000s_run': begin
     kernel_window=1
     calibrate_visibilities=0
@@ -177,6 +315,25 @@ pro mjw_fhd_versions
     ;restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
     snapshot_healpix_export = 0
     model_catalog_file_path = filepath('RFI_PLAW_Cat.sav',root=rootdir('FHD'),subdir='catalog_data')
+    end
+    
+    'kernel_window_rfi_run_single_source': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    ;restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    snapshot_healpix_export = 0
+    model_catalog_file_path = filepath('test_RFI_source_1061315448_zenith.sav',root=rootdir('FHD'),subdir='catalog_data')
     end
 
     'kernel_window_rfi_10x_run': begin

--- a/FHD_IDL_wrappers/mjw_fhd_versions.pro
+++ b/FHD_IDL_wrappers/mjw_fhd_versions.pro
@@ -80,7 +80,7 @@ pro mjw_fhd_versions
     ps_kspan=200.
     interpolate_kernel=1
     restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
-    extra_vis_filepath='/uvfits/extra_vis/1061312640_nsamplemax_RFI_plaw.uvfits'
+    extra_vis_filepath='/uvfits/extra_vis/1061312640_nsamplemax_RFI_plaw_1x.uvfits'
     in_situ_sim_input='/uvfits/input_vis/vis_data'
     end
 

--- a/FHD_IDL_wrappers/mjw_fhd_versions.pro
+++ b/FHD_IDL_wrappers/mjw_fhd_versions.pro
@@ -65,6 +65,25 @@ pro mjw_fhd_versions
     restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
     end
 
+    'kernel_window_rfi_sim_run': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='SET_THIS_PATH_MIKE'
+    in_situ_sim_onput='SET_THIS_PATH_MIKE'
+    end
+
     'kernel_window_rfi_run': begin
     kernel_window=1
     calibrate_visibilities=0

--- a/FHD_IDL_wrappers/mjw_fhd_versions.pro
+++ b/FHD_IDL_wrappers/mjw_fhd_versions.pro
@@ -80,8 +80,8 @@ pro mjw_fhd_versions
     ps_kspan=200.
     interpolate_kernel=1
     restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
-    extra_vis_filepath='SET_THIS_PATH_MIKE'
-    in_situ_sim_onput='SET_THIS_PATH_MIKE'
+    extra_vis_filepath='/uvfits/extra_vis/1061312640_nsamplemax_RFI_plaw_10x.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
     end
 
     'kernel_window_rfi_run': begin

--- a/bash_scripts/aws/fhd_job_aws.sh
+++ b/bash_scripts/aws/fhd_job_aws.sh
@@ -139,6 +139,11 @@ if [ "$run_fhd" -eq 1 ]; then  # Start FHD
             echo "Job Failed"
             exit 1
         fi
+        if [ -d /uvfits/input_vis ]; then
+            sudo chmod -R 777 /uvfits/input_vis
+        else
+            sudo mkdir -m 777 /uvfits/input_vis
+        fi
         # Download input_vis from S3
         sudo aws s3 cp ${input_vis} \
         /uvfits/input_vis/vis_data/ --recursive --exclude "*" --include "${obs_id}*" --quiet
@@ -159,11 +164,21 @@ if [ "$run_fhd" -eq 1 ]; then  # Start FHD
             echo "Job Failed"
             exit 1
         fi
+        if [ -d /uvfits/input_eor ]; then
+            sudo chmod -R 777 /uvfits/input_eor
+        else
+            sudo mkdir -m 777 /uvfits/input_eor
+        fi
         # Download input_eor from S3
         sudo aws s3 cp ${input_eor} \
         /uvfits/input_eor/vis_data/ --recursive --quiet
         echo Input EoR visibilities from ${input_eor} copied to /uvfits/input_eor/vis_data
-    fi
+        if [ -z $(ls /uvfits/input_eor/vis_data/) ]; then
+            >&2 echo "ERROR: input_eor file not found on filesystem"
+            echo "Job Failed"
+            exit 1
+        fi
+     fi
 
     #Get extra_vis files
     if [ ! -z ${extra_vis} ]; then

--- a/bash_scripts/aws/fhd_job_aws.sh
+++ b/bash_scripts/aws/fhd_job_aws.sh
@@ -178,7 +178,7 @@ if [ "$run_fhd" -eq 1 ]; then  # Start FHD
         sudo aws s3 cp ${extra_vis} \
         /uvfits/extra_vis/ --recursive --quiet
         # Check the download...
-        if [ -z $(ls /uvfits/extra_vis/) ]:
+        if [ -z $(ls /uvfits/extra_vis/) ]; then
             >&2 echo "ERROR: extra_vis file not found on filesystem"
             echo "Job Failed"
             exit 1

--- a/bash_scripts/aws/fhd_job_aws.sh
+++ b/bash_scripts/aws/fhd_job_aws.sh
@@ -170,13 +170,19 @@ if [ "$run_fhd" -eq 1 ]; then  # Start FHD
         # Check that the extra_vis file/loc exists on s3
         extra_vis_exists=$(aws s3 ls ${extra_vis})
         if [ -z "$extra_vis_exists" ]; then
-            >&2 echo "ERROR: extra_vis file not found"
+            >&2 echo "ERROR: extra_vis file not found on s3"
             echo "Job Failed"
             exit 1
         fi
         # Download extra_vis from s3
         sudo aws s3 cp ${extra_vis} \
         /uvfits/extra_vis/ --recursive --quiet
+        # Check the download...
+        if [ -z $(ls /uvfits/extra_vis/) ]:
+            >&2 echo "ERROR: extra_vis file not found on filesystem"
+            echo "Job Failed"
+            exit 1
+        fi
         echo Extra visibilities from ${extra_vis} copied to /uvfits/extra_vis/
     fi
 

--- a/bash_scripts/aws/fhd_job_aws.sh
+++ b/bash_scripts/aws/fhd_job_aws.sh
@@ -174,9 +174,10 @@ if [ "$run_fhd" -eq 1 ]; then  # Start FHD
             echo "Job Failed"
             exit 1
         fi
+        # Make the appropriate
         # Download extra_vis from s3
         sudo aws s3 cp ${extra_vis} \
-        /uvfits/extra_vis/ --recursive --quiet
+        /uvfits/extra_vis/ --quiet
         # Check the download...
         if [ -z $(ls /uvfits/extra_vis/) ]; then
             >&2 echo "ERROR: extra_vis file not found on filesystem"

--- a/bash_scripts/aws/fhd_job_aws.sh
+++ b/bash_scripts/aws/fhd_job_aws.sh
@@ -165,6 +165,21 @@ if [ "$run_fhd" -eq 1 ]; then  # Start FHD
         echo Input EoR visibilities from ${input_eor} copied to /uvfits/input_eor/vis_data
     fi
 
+    #Get extra_vis files
+    if [ ! -z ${extra_vis} ]; then
+        # Check that the extra_vis file/loc exists on s3
+        extra_vis_exists=$(aws s3 ls ${extra_vis})
+        if [ -z "$extra_vis_exists" ]; then
+            >&2 echo "ERROR: extra_vis file not found"
+            echo "Job Failed"
+            exit 1
+        fi
+        # Download extra_vis from s3
+        sudo aws s3 cp ${extra_vis} \
+        /uvfits/extra_vis/ --recursive --quiet
+        echo Extra visibilities from ${extra_vis} copied to /uvfits/extra_vis/
+    fi
+
     # Run FHD
     idl -IDL_DEVICE ps -IDL_CPU_TPOOL_NTHREADS $nslots -e $versions_script -args \
     $obs_id $outdir $version aws || :

--- a/bash_scripts/aws/run_fhd_aws.sh
+++ b/bash_scripts/aws/run_fhd_aws.sh
@@ -32,7 +32,7 @@ unset version
 #######Gathering the input arguments and applying defaults if necessary
 
 #Parse flags for inputs
-while getopts ":f:s:e:o:b:v:n:r:u:p:m:i:j:" option
+while getopts ":f:s:e:o:b:v:n:r:u:p:m:i:j:k:" option
 do
    case $option in
     f) obs_file_name="$OPTARG";; #text file of observation id's

--- a/bash_scripts/aws/run_fhd_aws.sh
+++ b/bash_scripts/aws/run_fhd_aws.sh
@@ -49,10 +49,12 @@ do
     r) run_ps=$OPTARG;; #Run eppsilon PS code (on individual obs)
     i) input_vis=$OPTARG;; #Optional input visibilities for in situ sim
     j) input_eor=$OPTARG;; #Optional input eor sim for in situ sim
+    k) extra_vis=$OPTARG;; #Optional additional visibilities for in situ sim (e.g. RFI visibilities)
     \?) echo "Unknown option: Accepted flags are -f (obs_file_name), -s (starting_obs), -e (ending obs), -o (output directory), "
         echo "-b (output bucket on S3), -v (version input for FHD),  -n (number of slots to use), "
         echo "-u (versions script), -p (path to uvfits files on S3), -m (path to metafits files on S3)"
         echo "-r (option to run eppsilon on each obs), -i (visibilities for in situ sim), -j (EoR sim)."
+        echo "-k (extra visibilities to add to simulation visibilities)"
         exit 1;;
     :) echo "Missing option argument for input flag"
        exit 1;;

--- a/bash_scripts/aws/run_fhd_aws.sh
+++ b/bash_scripts/aws/run_fhd_aws.sh
@@ -202,5 +202,5 @@ done
 
 for obs_id in "${good_obs_list[@]}"
 do
-   qsub -V -b y -cwd -v nslots=${nslots},outdir=${outdir},version=${version},s3_path=${s3_path},obs_id=$obs_id,versions_script=$versions_script,uvfits_s3_loc=$uvfits_s3_loc,metafits_s3_loc=$metafits_s3_loc,run_ps=${run_ps},input_vis=${input_vis},input_eor=$input_eor -e ${logdir} -o ${logdir} -pe smp ${nslots} -sync y fhd_job_aws.sh &
+   qsub -V -b y -cwd -v nslots=${nslots},outdir=${outdir},version=${version},s3_path=${s3_path},obs_id=$obs_id,versions_script=$versions_script,uvfits_s3_loc=$uvfits_s3_loc,metafits_s3_loc=$metafits_s3_loc,run_ps=${run_ps},input_vis=${input_vis},input_eor=$input_eor,extra_vis=$extra_vis -e ${logdir} -o ${logdir} -pe smp ${nslots} -sync y fhd_job_aws.sh &
 done


### PR DESCRIPTION
These were some modifications that I made while calculating RFI power spectrum contamination. They include an additional input to the run_fhd script that allows for passing extra simulated visibilities (the RFI in my practice, but in principle it could be additional noise, etc.) There is also some defensive if blocks in the inner wrapper to ensure that all directories exist with appropriate permissions. Finally there are some versions changes to my person versions file.