### PR TITLE
Add functionality for non-integer obs names

### DIFF
--- a/bash_scripts/aws/run_fhd_aws.sh
+++ b/bash_scripts/aws/run_fhd_aws.sh
@@ -32,7 +32,7 @@ unset version
 #######Gathering the input arguments and applying defaults if necessary
 
 #Parse flags for inputs
-while getopts ":f:s:e:o:b:v:n:r:u:p:m:i:j:k:c:t:" option
+while getopts ":f:s:e:o:b:v:n:r:u:p:m:i:j:k:c:t:a:" option
 do
    case $option in
     f) obs_file_name="$OPTARG";; #text file of observation id's
@@ -52,6 +52,7 @@ do
     k) extra_vis=$OPTARG;; #Optional additional visibilities for in situ sim (e.g. RFI visibilities)
     c) cal_transfer=$OPTARG;; #Option to transfer calibration solutions from another run
     t) model_uv_transfer=$OPTARG;; #Option to transfer model_uv_arr.sav from a calibration pre-run
+    a) non_integer_obs=$OPTARG;; #Specify that obsids are not integers - cannot sort.
     \?) echo "Unknown option: Accepted flags are -f (obs_file_name), -s (starting_obs), -e (ending obs), -o (output directory), "
         echo "-b (output bucket on S3), -v (version input for FHD),  -n (number of slots to use), "
         echo "-u (versions script), -p (path to uvfits files on S3), -m (path to metafits files on S3)"
@@ -159,56 +160,72 @@ fi
 sudo mkdir -p -m 777 ${outdir}/fhd_${version}/grid_out
 echo Output located at ${outdir}/fhd_${version}
 
+if [ $non_integer_obs -eq 1 ]; then
+    i=0
+    while read line
+    do
+        if [ ! -z "$line" ]; then
+            obs_id_array[$i]=$line
+            i=$((i + 1))
+        fi
+    done < "$obs_file_name"
+
+    unset good_obs_list
+    for obs_id in "${obs_id_array[@]}"; do
+        good_obs_list+=($obs_id)
+    done
+else
 #Read the obs file and put into an array, skipping blank lines if they exist
-i=0
-while read line
-do
-   if [ ! -z "$line" ]; then
-      obs_id_array[$i]=$line
-      i=$((i + 1))
-   fi
-done < "$obs_file_name"
+    i=0
+    while read line
+    do
+       if [ ! -z "$line" ]; then
+          obs_id_array[$i]=$line
+          i=$((i + 1))
+       fi
+    done < "$obs_file_name"
 
-#Find the max and min of the obs id array
-max=${obs_id_array[0]}
-min=${obs_id_array[0]}
+    #Find the max and min of the obs id array
+    max=${obs_id_array[0]}
+    min=${obs_id_array[0]}
 
-for obs_id in "${obs_id_array[@]}"
-do
-   #Update max if applicable
-   if [[ "$obs_id" -gt "$max" ]]
-   then
-	max="$obs_id"
-   fi
+    for obs_id in "${obs_id_array[@]}"
+    do
+       #Update max if applicable
+       if [[ "$obs_id" -gt "$max" ]]
+       then
+    	    max="$obs_id"
+       fi
 
-   #Update min if applicable
-   if [[ "$obs_id" -lt "$min" ]]
-   then
-	min="$obs_id"
-   fi
-done
+       #Update min if applicable
+       if [[ "$obs_id" -lt "$min" ]]
+       then
+ 	    min="$obs_id"
+       fi
+    done
 
-#If minimum not specified, start at minimum of obs_file
-if [ -z ${starting_obs} ]
-then
-   echo "Starting observation not specified: Starting at minimum of $obs_file_name"
-   starting_obs=$min
-fi
-
-#If maximum not specified, end at maximum of obs_file
-if [ -z ${ending_obs} ]
-then
-   echo "Ending observation not specified: Ending at maximum of $obs_file_name"
-   ending_obs=$max
-fi
-
-#Create a list of observations using the specified range, or the full observation id file.
-unset good_obs_list
-for obs_id in "${obs_id_array[@]}"; do
-    if [ $obs_id -ge $starting_obs ] && [ $obs_id -le $ending_obs ]; then
-	good_obs_list+=($obs_id)
+    #If minimum not specified, start at minimum of obs_file
+    if [ -z ${starting_obs} ]
+    then
+       echo "Starting observation not specified: Starting at minimum of $obs_file_name"
+       starting_obs=$min
     fi
-done
+
+    #If maximum not specified, end at maximum of obs_file
+    if [ -z ${ending_obs} ]
+    then
+       echo "Ending observation not specified: Ending at maximum of $obs_file_name"
+       ending_obs=$max
+    fi
+
+    #Create a list of observations using the specified range, or the full observation id file.
+    unset good_obs_list
+    for obs_id in "${obs_id_array[@]}"; do
+        if [ $obs_id -ge $starting_obs ] && [ $obs_id -le $ending_obs ]; then
+	    good_obs_list+=($obs_id)
+        fi
+    done
+fi
 
 #######End of gathering the input arguments and applying defaults if necessary
 
@@ -217,5 +234,5 @@ done
 
 for obs_id in "${good_obs_list[@]}"
 do
-   qsub -V -b y -cwd -v nslots=${nslots},outdir=${outdir},version=${version},s3_path=${s3_path},obs_id=${obs_id},versions_script=${versions_script},uvfits_s3_loc=${uvfits_s3_loc},metafits_s3_loc=${metafits_s3_loc},run_ps=${run_ps},input_vis=${input_vis},input_eor=${input_eor},extra_vis=${extra_vis},cal_transfer=${cal_transfer},model_uv_transfer=${model_uv_transfer} -e ${logdir} -o ${logdir} -pe smp ${nslots} -sync y fhd_job_aws.sh &
+    qsub -V -b y -cwd -v nslots=${nslots},outdir=${outdir},version=${version},s3_path=${s3_path},obs_id=${obs_id},versions_script=${versions_script},uvfits_s3_loc=${uvfits_s3_loc},metafits_s3_loc=${metafits_s3_loc},run_ps=${run_ps},input_vis=${input_vis},input_eor=${input_eor},extra_vis=${extra_vis},cal_transfer=${cal_transfer},model_uv_transfer=${model_uv_transfer} -e ${logdir} -o ${logdir} -pe smp ${nslots} -sync y fhd_job_aws.sh &
 done


### PR DESCRIPTION
This just adjusts the wrapper `run_fhd_aws.sh` so that you can have non-integer obsnames. The old functionality is still there. When using non-integer obsnames, they are not sorted in any way, and the start/end obs options don't do anything.