### PR TITLE
eppsilon aws wrapper issues

### DIFF
--- a/FHD_IDL_wrappers/eor_wrapper_defaults.pro
+++ b/FHD_IDL_wrappers/eor_wrapper_defaults.pro
@@ -33,6 +33,7 @@ PRO eor_wrapper_defaults,extra
   beam_offset_time=56 ; make this a default. But it won't compound with setting it directly in a version so I think it's ok.
   beam_clip_floor=1
   interpolate_kernel=1
+  beam_recalculate=1
 
   ;Calibration keywords
   cable_bandpass_fit=1

--- a/FHD_IDL_wrappers/mjw_fhd_versions.pro
+++ b/FHD_IDL_wrappers/mjw_fhd_versions.pro
@@ -85,6 +85,27 @@ pro mjw_fhd_versions
     remove_sim_flags=1
     end
 
+    'kernel_window_rfi_sim_single_source_run_no_bubbles_Double_DTV_25_times_GLEAM_0.3': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    beam_nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='/uvfits/extra_vis/1061315448_Double_DTV_RFI_nsamplemax_25_times.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
+    remove_sim_flags=1
+    model_catalog_file_path=filepath('GLEAM_v2_plus_rlb2019_pos_0.3.sav', root=rootdir('FHD'),subdir='catalog_data')
+    end
+
     'kernel_window_control_run_leave_flags_write_uvf_single_source': begin
     kernel_window=1
     calibrate_visibilities=0
@@ -100,7 +121,7 @@ pro mjw_fhd_versions
     interpolate_kernel=1
     restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
     save_uvf=1
-    model_catalog_filepath=filepath('test_source_1Jy_RA_350_dec_-26.8.sav',root=rootdir('FHD'),subdir='catalog_data/simulation')
+    model_catalog_file_path=filepath('test_source_1Jy_RA_350_dec_-26.8.sav',root=rootdir('FHD'),subdir='catalog_data/simulation')
     end
 
     'kernel_window_control_run_leave_flags_write_uvf': begin
@@ -137,6 +158,137 @@ pro mjw_fhd_versions
     restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
     end
 
+    'kernel_window_control_run_leave_flags_no_edge': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    beam_nfreq_avg=384
+    channel_edge_flag_width=0
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    end
+
+    'kernel_window_control_run_leave_flags_no_edge_0.3': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    beam_nfreq_avg=384
+    channel_edge_flag_width=0
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    model_catalog_file_path=filepath('GLEAM_v2_plus_rlb2019_pos_0.3.sav', root=rootdir('FHD'),subdir='catalog_data')
+    end
+    
+    'kernel_window_control_run_leave_flags_no_edge_0.5': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    beam_nfreq_avg=384
+    channel_edge_flag_width=0
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    model_catalog_file_path=filepath('GLEAM_v2_plus_rlb2019_pos_0.5.sav', root=rootdir('FHD'),subdir='catalog_data')
+    end
+
+    'kernel_window_control_run_leave_flags_no_edge_0.7': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    beam_nfreq_avg=384
+    channel_edge_flag_width=0
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    model_catalog_file_path=filepath('GLEAM_v2_plus_rlb2019_pos_0.7.sav', root=rootdir('FHD'),subdir='catalog_data')
+    end
+
+
+    'kernel_window_control_run_0.3': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    beam_nfreq_avg=384
+    channel_edge_flag_width=0
+    ps_kspan=200.
+    unflag_all=1
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    model_catalog_file_path=filepath('GLEAM_v2_plus_rlb2019_pos_0.3.sav', root=rootdir('FHD'),subdir='catalog_data')
+    end
+
+
+    'kernel_window_control_run_0.5': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    debug_dim=1
+    unflag_all=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    beam_nfreq_avg=384
+    channel_edge_flag_width=0
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    model_catalog_file_path=filepath('GLEAM_v2_plus_rlb2019_pos_0.5.sav', root=rootdir('FHD'),subdir='catalog_data')
+    end
+
+    'kernel_window_control_run_0.7': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    beam_nfreq_avg=384
+    channel_edge_flag_width=0
+    ps_kspan=200.
+    unflag_all=1
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    model_catalog_file_path=filepath('GLEAM_v2_plus_rlb2019_pos_0.7.sav', root=rootdir('FHD'),subdir='catalog_data')
+    end
+
+
     'Barry_2019_image_step_coarse_beam': begin
     model_uv_transfer='/uvfits/transfer/' + obs_id + '_model_uv_arr.sav'
     kernel_window=1
@@ -148,7 +300,6 @@ pro mjw_fhd_versions
     return_cal_visibilities=0
     FoV=0
     time_cut=-2
-    interpolate_kernel=1
     cal_time_average=0
     model_visibilities=1
     transfer_calibration = '/uvfits/transfer/' + obs_id + '_cal.sav'
@@ -476,7 +627,7 @@ pro mjw_fhd_versions
     ps_kspan=200.
     interpolate_kernel=1
     restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
-    model_catalog_filepath=filepath('test_RFI_source_1061315448_zenith.sav',root=rootdir('FHD'),subdir='catalog_data')
+    model_catalog_file_path=filepath('test_RFI_source_1061315448_zenith.sav',root=rootdir('FHD'),subdir='catalog_data')
     end
     
     'kernel_window_control_run_plaw_zenith': begin
@@ -494,7 +645,7 @@ pro mjw_fhd_versions
       ps_kspan=200.
       interpolate_kernel=1
       restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
-      model_catalog_filepath=filepath('test_RFI_source_1061315448_zenith.sav',root=rootdir('FHD'),subdir='catalog_data/simulation')
+      model_catalog_file_path=filepath('test_RFI_source_1061315448_zenith.sav',root=rootdir('FHD'),subdir='catalog_data/simulation')
     end
 
     'kernel_window_control_run_zenith_navg1': begin

--- a/FHD_IDL_wrappers/mjw_fhd_versions.pro
+++ b/FHD_IDL_wrappers/mjw_fhd_versions.pro
@@ -205,6 +205,31 @@ pro mjw_fhd_versions
     beam_clip_floor=1
     end
 
+    'Barry_2019_image_step_psf_dim': begin
+    model_uv_transfer='/uvfits/transfer/' + obs_id + '_model_uv_arr.sav'
+    kernel_window=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_nfreq_avg=1
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    return_cal_visibilities=0
+    FoV=0
+    time_cut=-2
+    interpolate_kernel=1
+    cal_time_average=0
+    model_visibilities=1
+    transfer_calibration = '/uvfits/transfer/' + obs_id + '_cal.sav'
+    diffuse_calibrate=0
+    diffuse_model=0
+    digital_gain_jump_polyfit=1
+    ps_kspan=200.
+    calibration_auto_fit=1
+    cal_bp_transfer=0
+    beam_clip_floor=1
+    psf_dim=22
+    end
+
     'Barry_2019_image_step_old_nfreq_avg': begin
     model_uv_transfer='/uvfits/transfer/' + obs_id + '_model_uv_arr.sav'
     kernel_window=1

--- a/FHD_IDL_wrappers/mjw_fhd_versions.pro
+++ b/FHD_IDL_wrappers/mjw_fhd_versions.pro
@@ -20,6 +20,70 @@ pro mjw_fhd_versions
 
   case version of
 
+    'kernel_window_rfi_sim_single_source_run_no_bubbles_Double_DTV_25_times_flagged_achromatic_GLEAM': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=0
+    channel_edge_flag_width=0
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    beam_nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='/uvfits/extra_vis/1061315448_Double_DTV_RFI_nsamplemax_25_times_flagged_achromatic.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
+    remove_sim_flags=1
+    use_extra_flags=1
+    end
+
+    'kernel_window_rfi_sim_single_source_run_no_bubbles_Double_DTV_25_times_flagged_GLEAM': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=0
+    channel_edge_flag_width=0
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    beam_nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='/uvfits/extra_vis/1061315448_Double_DTV_RFI_nsamplemax_25_times_flagged.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
+    remove_sim_flags=1
+    use_extra_flags=1
+    end
+
+
+    'kernel_window_rfi_sim_single_source_run_no_bubbles_Double_DTV_25_times_GLEAM': begin
+    kernel_window=1
+    calibrate_visibilities=0
+    return_cal_visibilities=0
+    calibration_visibilities_subtract=0
+    model_visibilities=1
+    save_visibilities=1
+    unflag_all=1
+    debug_dim=1
+    beam_mask_threshold=1e3
+    beam_clip_floor=1
+    beam_nfreq_avg=384
+    ps_kspan=200.
+    interpolate_kernel=1
+    restrict_hpx_inds='EoR0_high_healpix_inds_3x.idlsave'
+    extra_vis_filepath='/uvfits/extra_vis/1061315448_Double_DTV_RFI_nsamplemax_25_times.uvfits'
+    in_situ_sim_input='/uvfits/input_vis/vis_data'
+    remove_sim_flags=1
+    end
 
     'kernel_window_control_run_leave_flags_write_uvf_single_source': begin
     kernel_window=1

--- a/bash_scripts/aws/eppsilon_job_aws.sh
+++ b/bash_scripts/aws/eppsilon_job_aws.sh
@@ -154,6 +154,7 @@ if [ -z ${cube_type} ]; then
 fi
 ####
 
+echo "arg_string is $arg_string"
 idl -IDL_DEVICE ps -IDL_CPU_TPOOL_NTHREADS $nslots -e aws_ps_job -args $arg_string || :
 
 if [ $? -eq 0 ]

--- a/bash_scripts/aws/eppsilon_job_aws.sh
+++ b/bash_scripts/aws/eppsilon_job_aws.sh
@@ -151,6 +151,15 @@ fi
 if [ -z ${cube_type} ]; then
     sudo aws s3 cp ${file_path_cubes}/ps/data/uvf_cubes/ /ps/data/uvf_cubes --recursive --quiet \
      --exclude "*" --include "${version}*"
+
+    # Verify that the cubes downloaded correctly
+    file_num=$(ls /ps/data/uvf_cubes/${version}* | wc -li)
+    echo "file_num is $file_num"
+    if [ $file_num -eq 0 ]; then
+      >&2 echo "ERROR: no uvf cubes present in uvf_cubes directory. Something is wrong."
+      echo "Job Failed"
+      exit 1
+    fi
 fi
 ####
 

--- a/bash_scripts/aws/run_eppsilon_aws.sh
+++ b/bash_scripts/aws/run_eppsilon_aws.sh
@@ -179,7 +179,8 @@ if [ "$ps_only" -ne "1" ]; then
 	          echo Combined_obs_${version}_int_chunk${chunk} >> $sub_cubes_list # trick it into finding our sub cubes
         done
 
-        idlist_int_chunks=(`qstat | grep "int_c_" | cut -b -7`)
+        # Added pipe to tail, untested 10/20/2020
+        idlist_int_chunks=(`qstat | grep "int_c_" | cut -b -7 | tail -n 1`)
 	      idlist_int_chunks=$( IFS=$','; echo "${idlist_int_chunks[*]}" )
 	      hold_str="-hold_jid ${idlist_int_chunks}"
 
@@ -195,7 +196,8 @@ if [ "$ps_only" -ne "1" ]; then
 	         done
 	      done
 
-        idlist_int_master=(`qstat | grep "int_m_" | cut -b -7`)
+        # Added pipe to tail, untested 10/20/2020
+        idlist_int_master=(`qstat | grep "int_m_" | cut -b -7 | tail -n 1`)
 	      idlist_int_master=$( IFS=$','; echo "${idlist_int_master[*]}" )
 	      hold_str="-hold_jid ${idlist_int_master}"
 
@@ -279,7 +281,7 @@ if [ -z ${ps_plots_only} ]; then
 
                 if [ ! -z "$pids" ]; then pids="$!"; else pids=($pids "$!"); fi
                 # If there are multiple w_xx_even etc. jobs in the queue, grab the latest one
-                job_id=(`qstat | grep "${cube_type_letter}_${pol}_${evenodd}" | cut -b -7 | tail -n 1`) 
+                job_id=(`qstat | grep "${cube_type_letter}_${pol}_${evenodd}" | cut -b -7 | tail -n 1`)
                 if [ -z "$id_list" ]; then id_list=${job_id};else id_list=${id_list},${job_id};fi
 
                 if [ $cube_type = "weights" ]

--- a/bash_scripts/aws/run_eppsilon_aws.sh
+++ b/bash_scripts/aws/run_eppsilon_aws.sh
@@ -255,6 +255,8 @@ hold_str_int=$hold_str
 unset id_list
 unset pids
 
+echo "hold_str_int is $hold_str_int"
+
 if [ -z ${ps_plots_only} ]; then
 
     for pol in "${pol_arr[@]}"
@@ -271,7 +273,7 @@ if [ -z ${ps_plots_only} ]; then
                 fi
 
                 cube_type_letter=${cube_type:0:1}
-
+                echo "hold_str_temp for ${cube_type_letter}_${pol}_${evenodd}is ${hold_str_temp}"
                 message=$(qsub ${hold_str_temp} -V -b y -cwd -v file_path_cubes=$FHDdir,obs_list_path=$integrate_list,obs_list_array="$integrate_array",version=$version,nslots=$nslots,cube_type=$cube_type,pol=$pol,evenodd=$evenodd,single_obs=$single_obs -e ${errfile} -o ${outfile} -N ${cube_type_letter}_${pol}_${evenodd} -pe smp $nslots eppsilon_job_aws.sh)
                 message=($message)
 
@@ -289,5 +291,6 @@ if [ -z ${ps_plots_only} ]; then
 
 fi
 
+echo "id_list for PS_plots is $id_list"
 #final plots
 qsub -hold_jid $id_list -V -v file_path_cubes=$FHDdir,obs_list_path=$integrate_list,obs_list_array="$integrate_array",version=$version,nslots=$nslots,single_obs=$single_obs -e ${errfile} -o ${outfile} -N PS_plots -pe smp $nslots $(which eppsilon_job_aws.sh) &

--- a/bash_scripts/aws/run_eppsilon_aws.sh
+++ b/bash_scripts/aws/run_eppsilon_aws.sh
@@ -214,8 +214,8 @@ if [ "$ps_only" -ne "1" ]; then
         	    qsub ${hold_str} -V -b y -v file_path_cubes=$FHDdir,obs_list_array="$chunk_obs_array",obs_list_path=$chunk_obs_list,version=$version,chunk=$chunk,nslots=$nslots,legacy=$legacy,evenodd=$evenodd,pol=$pol -e $errfile -o $outfile -N int_${version} -pe smp $nslots integration_job_aws.sh
 	         done
 	      done
-
-        idlist_int=(`qstat | grep "int_" | cut -b -7`)
+        # Grab the last int job instead of the first one
+        idlist_int=(`qstat | grep "int_" | cut -b -7 | tail -n 1`)
         hold_str="-hold_jid ${idlist_int}"
 
     fi
@@ -278,7 +278,8 @@ if [ -z ${ps_plots_only} ]; then
                 message=($message)
 
                 if [ ! -z "$pids" ]; then pids="$!"; else pids=($pids "$!"); fi
-                job_id=(`qstat | grep "${cube_type_letter}_${pol}_${evenodd}" | cut -b -7`)
+                # If there are multiple w_xx_even etc. jobs in the queue, grab the latest one
+                job_id=(`qstat | grep "${cube_type_letter}_${pol}_${evenodd}" | cut -b -7 | tail -n 1`) 
                 if [ -z "$id_list" ]; then id_list=${job_id};else id_list=${id_list},${job_id};fi
 
                 if [ $cube_type = "weights" ]

--- a/eppsilon_IDL_wrappers/aws_ps_single_obs_job.pro
+++ b/eppsilon_IDL_wrappers/aws_ps_single_obs_job.pro
@@ -20,6 +20,6 @@ pro aws_ps_single_obs_job
   if refresh_ps eq 0 then undefine, refresh_ps
   if uvf_input eq 0 then undefine, uvf_input
 
-  ps_wrapper, outdir+'/fhd_'+fhd_version, obs_id, /png, /plot_kpar_power, refresh_ps=refresh_ps, uvf_input=uvf_input, wt_cutoffs=wt_cutoffs, freq_ch_range=[9, 126]
+  ps_wrapper, outdir+'/fhd_'+fhd_version, obs_id, /png, /plot_kpar_power, refresh_ps=refresh_ps, uvf_input=uvf_input, wt_cutoffs=wt_cutoffs
 
 end

--- a/eppsilon_IDL_wrappers/aws_ps_single_obs_job.pro
+++ b/eppsilon_IDL_wrappers/aws_ps_single_obs_job.pro
@@ -20,6 +20,6 @@ pro aws_ps_single_obs_job
   if refresh_ps eq 0 then undefine, refresh_ps
   if uvf_input eq 0 then undefine, uvf_input
 
-  ps_wrapper, outdir+'/fhd_'+fhd_version, obs_id, /png, /plot_kpar_power, refresh_ps=refresh_ps, uvf_input=uvf_input, wt_cutoffs=wt_cutoffs
+  ps_wrapper, outdir+'/fhd_'+fhd_version, obs_id, /png, /plot_kpar_power, refresh_ps=refresh_ps, uvf_input=uvf_input, wt_cutoffs=wt_cutoffs, freq_ch_range=[9, 126]
 
 end


### PR DESCRIPTION
This PR fixes a scheduling bug that was giving the wrong hold_str when multiple job versions were in the queue. This has been tested for runs where the submitted integration list does not need additional chunking (when the submitted list is less than 20 obs long). The fix exists in the chunked case, but I have not tested it.